### PR TITLE
fix(ci): add write permissions for updatecli workflow

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -5,13 +5,12 @@ on:
   schedule:
     - cron: '0 6 * * 1' # Every Monday at 6am UTC
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   updatecli:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.repository_owner == 'gounthar'
     steps:
       - name: Checkout

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 6 * * 1' # Every Monday at 6am UTC
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   updatecli:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `contents: write` and `pull-requests: write` permissions to the updatecli workflow
- Without these, `GITHUB_TOKEN` cannot push branches or create PRs, causing `updatecli apply` to fail with "Permission denied"

## Evidence

From [run #22735987489](https://github.com/gounthar/xcp-ng-scaleway-elastic-metal/actions/runs/22735987489):
```
ERROR: push: authorization failed: Permission to gounthar/xcp-ng-scaleway-elastic-metal.git denied to github-actions[bot].
```

## Test plan

- [ ] Merge and trigger `workflow_dispatch` — updatecli should create a PR bumping `actions/checkout` from v4 to v6

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflow configuration to improve automation permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->