### PR TITLE
fix(ci): add workflows permission for updatecli

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      workflows: write
     if: github.repository_owner == 'gounthar'
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Add `workflows: write` permission to the updatecli job

## Motivation

The github-actions updatecli manifest bumps `actions/checkout` and `updatecli-action` versions in `.github/workflows/updatecli.yaml`. GitHub refuses pushes that modify workflow files without explicit `workflows` permission:

```
refusing to allow a GitHub App to create or update workflow
.github/workflows/updatecli.yaml without workflows permission
```

From [run #22736595899](https://github.com/gounthar/xcp-ng-scaleway-elastic-metal/actions/runs/22736595899).

## Test plan

- [ ] Merge, trigger `workflow_dispatch`, verify updatecli creates a PR bumping `actions/checkout` from v4 to v6