### PR TITLE
fix(ci): move workflows permission to workflow level

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -5,13 +5,15 @@ on:
   schedule:
     - cron: '0 6 * * 1' # Every Monday at 6am UTC
 
+permissions:
+  workflows: write
+
 jobs:
   updatecli:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-      workflows: write
     if: github.repository_owner == 'gounthar'
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Move `workflows: write` from job-level to workflow-level permissions
- `workflows` is only valid at the workflow level — GitHub rejects it at job level with "Unexpected value 'workflows'"

## Changes

```yaml
# Workflow level (only valid location for workflows permission)
permissions:
  workflows: write

jobs:
  updatecli:
    # Job level (least privilege for everything else)
    permissions:
      contents: write
      pull-requests: write
```

## Test plan

- [ ] Merge, trigger `workflow_dispatch`, verify workflow runs and updatecli creates a PR