### PR TITLE
fix(ci): fix updatecli token and add lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,34 @@
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint YAML files
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: .
+          config_data: |
+            extends: default
+            rules:
+              line-length:
+                max: 120
+              truthy:
+                check-keys: false
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint GitHub Actions workflows
+        uses: raven-actions/actionlint@v2

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -5,9 +5,6 @@ on:
   schedule:
     - cron: '0 6 * * 1' # Every Monday at 6am UTC
 
-permissions:
-  workflows: write
-
 jobs:
   updatecli:
     runs-on: ubuntu-latest
@@ -25,10 +22,10 @@ jobs:
       - name: Run Updatecli in Dry Run mode
         run: updatecli diff --config ./updatecli/updatecli.d
         env:
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.UPDATECLI_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Run Updatecli in Apply mode
         if: github.ref == 'refs/heads/main'
         run: updatecli apply --config ./updatecli/updatecli.d
         env:
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.UPDATECLI_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove invalid `workflows: write` permission (not a valid GitHub Actions permission key)
- Use `UPDATECLI_PAT` secret with `GITHUB_TOKEN` fallback for updatecli
- Add lint workflow with yamllint (YAML syntax) and actionlint (GitHub Actions validation)

## Motivation

`GITHUB_TOKEN` cannot push changes to `.github/workflows/` files regardless of permissions. This is a GitHub security restriction. A PAT with the `workflow` scope is required.

With `UPDATECLI_PAT` not yet configured, updatecli will:
- **XCP-ng and Debian manifests**: work with `GITHUB_TOKEN`
- **GitHub Actions manifest**: fail gracefully (needs PAT)

To enable full automation later: create a PAT with `repo` + `workflow` scopes, add it as `UPDATECLI_PAT` repository secret.

## Test plan

- [ ] Lint workflow runs on this PR (self-validating)
- [ ] After merge, `workflow_dispatch` updatecli — XCP-ng and Debian pipelines should succeed