### PR TITLE
ci: use updatecli pipeline subcommand

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -20,12 +20,12 @@ jobs:
         uses: updatecli/updatecli-action@v2.100.0
 
       - name: Run Updatecli in Dry Run mode
-        run: updatecli diff --config ./updatecli/updatecli.d
+        run: updatecli pipeline diff --config ./updatecli/updatecli.d
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.UPDATECLI_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Run Updatecli in Apply mode
         if: github.ref == 'refs/heads/main'
-        run: updatecli apply --config ./updatecli/updatecli.d
+        run: updatecli pipeline apply --config ./updatecli/updatecli.d
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.UPDATECLI_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The workflow calls the top-level `updatecli diff`/`updatecli apply` commands, which newer updatecli releases mark as deprecated in favour of `updatecli pipeline diff`/`updatecli pipeline apply`. They still work but print a deprecation warning on every run.

The `updatecli-action` step installs the latest updatecli binary and pins no version, so the `pipeline` subcommand is available. No functional change, just drops the warning.